### PR TITLE
Add missing comma to the config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ i18n.json - This optional config file should be located in the project_root and 
 
 ```JSON
 {
-    "function_name": "t"
+    "function_name": "t",
     "messages_dir": "/messages",
     "default_lang": "en"
 }


### PR DESCRIPTION
Otherwise the plugin breaks at launch with this config.

Thanks for the plugin, by the way, didn't even hope to find an i18n-ally equivalent for nvim! (Zed has none, for example.)