### PR TITLE
Add support for nested keys, preserve translation files and add config options

### DIFF
--- a/example.json
+++ b/example.json
@@ -1,0 +1,7 @@
+{
+  "login": "Login",
+  "store": {
+    "addtocart": "Add to Cart",
+    "checkout": "Checkout"
+  }
+}

--- a/lua/i18n-menu/dig.lua
+++ b/lua/i18n-menu/dig.lua
@@ -10,6 +10,25 @@ function M.dig(table, path)
   return M.dig(table[head], tail)
 end
 
+function M.place(table, path, value)
+  local head, tail = string.match(path, "([^.]*)%.?(.*)")
+
+  if tail == "" then
+    table[head] = value
+    return
+  end
+
+  if not table[head] then
+    table[head] = {}
+  end
+
+  if type(table[head]) ~= "table" then
+    error("Attempt to overwrite existing string with an object")
+  end
+
+  return M.place(table[head], tail, value)
+end
+
 local translations = {
   login = "Login",
   store = {
@@ -25,11 +44,18 @@ local translations = {
 }
 
 if debug.getinfo(3) == nil then
-  print("Running tests...")
+  print("Running dig tests...")
   assert(M.dig(translations, "login") == "Login")
   assert(M.dig(translations, "store.addToCart") == "Add to Cart")
   assert(M.dig(translations, "faq.0.question") == "How can I pay?")
   assert(M.dig(translations, "store.orders") == nil)
+  print("Running place tests...")
+  M.place(translations, "login", "Sign In")
+  assert(M.dig(translations, "login") == "Sign In")
+  M.place(translations, "store.checkout", "Checkout Now")
+  assert(M.dig(translations, "store.checkout") == "Checkout Now")
+  M.place(translations, "guide.greeting", "Hello")
+  assert(M.dig(translations, "guide.greeting") == "Hello")
   print("All good.")
 else
   return M

--- a/lua/i18n-menu/dig.lua
+++ b/lua/i18n-menu/dig.lua
@@ -1,0 +1,36 @@
+local M = {}
+
+function M.dig(table, path)
+  if not table or type(table) == "string" then
+    return table
+  end
+
+  local head, tail = string.match(path, "([^.]*)%.?(.*)")
+
+  return M.dig(table[head], tail)
+end
+
+local translations = {
+  login = "Login",
+  store = {
+    addToCart = "Add to Cart",
+    checkout = "Checkout"
+  },
+  faq = {
+    ["0"] = {
+      question = "How can I pay?",
+      answer = "Only gold coins are accepted."
+    }
+  }
+}
+
+if debug.getinfo(3) == nil then
+  print("Running tests...")
+  assert(M.dig(translations, "login") == "Login")
+  assert(M.dig(translations, "store.addToCart") == "Add to Cart")
+  assert(M.dig(translations, "faq.0.question") == "How can I pay?")
+  assert(M.dig(translations, "store.orders") == nil)
+  print("All good.")
+else
+  return M
+end

--- a/lua/i18n-menu/dig.lua
+++ b/lua/i18n-menu/dig.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.dig(table, path)
-  if not table or type(table) == "string" then
+  if not table or type(table) ~= "table" then
     return table
   end
 

--- a/lua/i18n-menu/dig.lua
+++ b/lua/i18n-menu/dig.lua
@@ -1,17 +1,21 @@
 local M = {}
 
+local function path_hd(path)
+  return string.match(path, "([^.]*)%.?(.*)")
+end
+
 function M.dig(table, path)
   if not table or type(table) ~= "table" then
     return table
   end
 
-  local head, tail = string.match(path, "([^.]*)%.?(.*)")
+  local head, tail = path_hd(path)
 
   return M.dig(table[head], tail)
 end
 
 function M.place(table, path, value)
-  local head, tail = string.match(path, "([^.]*)%.?(.*)")
+  local head, tail = path_hd(path)
 
   if tail == "" then
     table[head] = value

--- a/lua/i18n-menu/init.lua
+++ b/lua/i18n-menu/init.lua
@@ -4,6 +4,7 @@ local ts = vim.treesitter
 
 local M = {}
 local util = require("i18n-menu.util")
+local dig = require("i18n-menu.dig")
 
 function M.highlight_translation_references()
   local config = util.read_config_file()
@@ -52,15 +53,18 @@ function M.highlight_translation_references()
 
     for _, file in ipairs(translation_files) do
       local translations = util.load_translations(file)
-      if translations[translation_key] then
+      if dig.dig(translations, translation_key) then
         break
       end
       is_missing_translation = false
     end
 
-    local hl_group = is_missing_translation and "Comment" or "ErrorMsg"
     local start_row, start_col, end_row, end_col = translation_key_node:range()
-    api.nvim_buf_add_highlight(bufnr, -1, hl_group, start_row, start_col, end_col)
+
+    local hl_group = util.highlight_group(is_missing_translation)
+    if hl_group then
+      api.nvim_buf_add_highlight(bufnr, -1, hl_group, start_row, start_col, end_col)
+    end
 
     if not is_missing_translation then
       table.insert(diagnostics, {

--- a/lua/i18n-menu/init.lua
+++ b/lua/i18n-menu/init.lua
@@ -129,7 +129,7 @@ function M.show_translation_menu()
       if new_translation ~= "" then
         local translation_file = messages_dir .. "/" .. selected_language .. ".json"
         local translations = util.load_translations(translation_file)
-        translations[translation_key] = new_translation
+        dig.place(translations, translation_key, new_translation)
         util.save_translations(translation_file, translations)
         M.highlight_translation_references()
       end

--- a/lua/i18n-menu/json_util.lua
+++ b/lua/i18n-menu/json_util.lua
@@ -1,0 +1,29 @@
+local M = {}
+
+function M.keys_order(filepath)
+  local ans = {}
+
+  for line in io.lines(filepath) do
+    local indent, key = string.match(line, '( +)"([^"]+)"')
+    if type(indent) == "string" then
+      local level = math.floor(string.len(indent) / 2)
+      if ans[level] then
+        table.insert(ans[level], key)
+      else
+        ans[level] = { key }
+      end
+    end
+  end
+
+  return ans
+end
+
+if debug.getinfo(3) == nil then
+  print("Running keys_order tests...")
+  local order = M.keys_order("example.json")
+  assert(order[1][1] == "login")
+  assert(order[1][2] == "store")
+  print("All good.")
+else
+  return M
+end

--- a/lua/i18n-menu/util.lua
+++ b/lua/i18n-menu/util.lua
@@ -35,7 +35,7 @@ function M.save_translations(file, translations)
   if f == nil then
     return false
   end
-  local prettyContent = json:pretty_print(translations)
+  local prettyContent = json:pretty_print(translations, nil, true)
   f:write(prettyContent)
   f:close()
   return true

--- a/lua/i18n-menu/util.lua
+++ b/lua/i18n-menu/util.lua
@@ -3,6 +3,7 @@ local fn = vim.fn
 local M = {}
 local ts = vim.treesitter
 local json = require("snippet_converter.utils.json_utils")
+local dig = require("i18n-menu.dig")
 
 function M.load_translations(file)
   local f = io.open(file, "r")
@@ -164,6 +165,22 @@ function M.get_translation_key()
     end
   end
   return translation_key
+end
+
+function M.highlight_group(is_present)
+  local config = M.read_config_file()
+  local present_highlight = dig.dig(config, "present_highlight") or "Comment"
+  local missing_highlight = dig.dig(config, "missing_highlight") or "ErrorMsg"
+
+  if is_present and present_highlight ~= "" then
+    return present_highlight
+  end
+
+  if not is_present and missing_highlight ~= "" then
+    return missing_highlight
+  end
+
+  return nil
 end
 
 return M

--- a/lua/i18n-menu/util.lua
+++ b/lua/i18n-menu/util.lua
@@ -4,6 +4,7 @@ local M = {}
 local ts = vim.treesitter
 local json = require("snippet_converter.utils.json_utils")
 local dig = require("i18n-menu.dig")
+local json_util = require("i18n-menu.json_util")
 
 function M.load_translations(file)
   local f = io.open(file, "r")
@@ -31,11 +32,13 @@ function M.load_translations(file)
 end
 
 function M.save_translations(file, translations)
+  local order = json_util.keys_order(file)
+
   local f = io.open(file, "w")
   if f == nil then
     return false
   end
-  local prettyContent = json:pretty_print(translations, nil, true)
+  local prettyContent = json:pretty_print(translations, order, true)
   f:write(prettyContent)
   f:close()
   return true


### PR DESCRIPTION
This PR adds several different features -- I'm already using the plugin for work so I need all of them in the same branch -- sorry about that, feel free to cherry pick.

## Nested Keys Support

Support for translation files like
```json
{
  "login": "Login",
  "store": {
    "addToCart": "Add to Cart",
    "checkout": "Checkout"
  }
}
```
with keys like `store.addToCart`. See [unit tests](https://github.com/colorfulfool/i18n-menu.nvim/blob/e76224e9f331a8eec1e2f93ee93bfbd019a75ee8/lua/i18n-menu/dig.lua#L32) for examples.

## Preserve Line Breaks

Translation files with line breaks within values are no longer messed up on save.

## Preserve Keys Order

Order of the keys in the translation file is no longer changed on save. Well, the root level at least. This feature [is provided by snippet_converter](https://github.com/colorfulfool/i18n-menu.nvim/blob/e76224e9f331a8eec1e2f93ee93bfbd019a75ee8/lua/i18n-menu/util.lua#L41) and it's limited in its abilities.

## New Configuration Options

The default behaviour is unchanged and no additional keys are required in the config file. But by adding certain keys to `i18n.json` bahviour of the plugin can be customized:

### Highlight Groups

Allows to disable highlighting

```json
{
  "present_highlight": "",
  "missing_highlight": "",
}
```

or change it

```json
{
  "present_highlight": "Comment",
  "missing_highlight": "Comment",
}
```

### Skip Language Select

Allows to skip language select menu go straight to the default lang every time. I use Crowdin at work, which takes care of other locales and feeds them back into the repo, so I never edit any locales except the default one.

```json
{
  "skip_lang_select": true
}
```