### PR TITLE
Add simple heuristics to the default translation

### DIFF
--- a/lua/i18n-menu/init.lua
+++ b/lua/i18n-menu/init.lua
@@ -5,6 +5,7 @@ local ts = vim.treesitter
 local M = {}
 local util = require("i18n-menu.util")
 local dig = require("i18n-menu.dig")
+local smart_default = require("i18n-menu.smart_default")
 
 function M.highlight_translation_references()
   local config = util.read_config_file()
@@ -179,7 +180,10 @@ function M.translate_default()
 
   local translation_file = messages_dir .. "/" .. default_lang .. ".json"
   local translations = util.load_translations(translation_file)
-  dig.place(translations, translation_key, translation_key)
+  local default_translation = smart_default.smart_default(translation_key)
+
+  dig.place(translations, translation_key, default_translation)
+
   util.save_translations(translation_file, translations)
   M.highlight_translation_references()
   M.show_translation_menu()

--- a/lua/i18n-menu/init.lua
+++ b/lua/i18n-menu/init.lua
@@ -5,7 +5,6 @@ local ts = vim.treesitter
 local M = {}
 local util = require("i18n-menu.util")
 local dig = require("i18n-menu.dig")
-local smart_default = require("i18n-menu.smart_default")
 
 function M.highlight_translation_references()
   local config = util.read_config_file()

--- a/lua/i18n-menu/init.lua
+++ b/lua/i18n-menu/init.lua
@@ -180,7 +180,7 @@ function M.translate_default()
 
   local translation_file = messages_dir .. "/" .. default_lang .. ".json"
   local translations = util.load_translations(translation_file)
-  local default_translation = smart_default.smart_default(translation_key)
+  local default_translation = util.default_translation(translation_key)
 
   dig.place(translations, translation_key, default_translation)
 

--- a/lua/i18n-menu/smart_default.lua
+++ b/lua/i18n-menu/smart_default.lua
@@ -1,0 +1,24 @@
+local M = {}
+
+function M.smart_default(text)
+  local last_segment = string.match(text, "[^.]+$")
+  return last_segment:gsub("(%u)", " %1"):gsub("^ ", "")
+end
+
+local function assert_equal(actual, expected)
+  if actual == expected then
+    print(string.format("\27[32m%s == %s\27[0m", actual, expected))
+  else
+    print(string.format("\27[31m%s != %s\27[0m", actual, expected))
+    error("Assertion failed.")
+  end
+end
+
+if debug.getinfo(3) == nil then
+  print("Running smart_default tests...")
+  assert_equal(M.smart_default("matchBonuses.Select"), "Select")
+  assert_equal(M.smart_default("matchBonuses.SelectAll"), "Select All")
+  print("All good.")
+else
+  return M
+end

--- a/lua/i18n-menu/util.lua
+++ b/lua/i18n-menu/util.lua
@@ -5,6 +5,7 @@ local ts = vim.treesitter
 local json = require("snippet_converter.utils.json_utils")
 local dig = require("i18n-menu.dig")
 local json_util = require("i18n-menu.json_util")
+local smart_default = require("i18n-menu.smart_default")
 
 function M.load_translations(file)
   local f = io.open(file, "r")
@@ -184,6 +185,17 @@ function M.highlight_group(is_present)
   end
 
   return nil
+end
+
+function M.default_translation(translation_key)
+  local config = M.read_config_file()
+  local default_translation_strat = dig.dig(config, "default_translation")
+
+  if default_translation_strat == "smart_default" then
+    return smart_default.smart_default(translation_key)
+  end
+
+  return translation_key
 end
 
 return M


### PR DESCRIPTION
Another small addition: in `:TranslateDefault`, instead of using the key verbatim, take only the last segment and transform it from camel case to human-readable, e.g. "home.navigation.ContactForm" => "Contact Form".

### Configuration
Default behaviour is unchanged, the heuristics can be enabled by adding the following to i18n.json:
```
"default_translation": "smart_default"
```