### PR TITLE
Add function_patterns config option

### DIFF
--- a/lua/i18n-menu/init.lua
+++ b/lua/i18n-menu/init.lua
@@ -182,7 +182,7 @@ function M.setup()
   api.nvim_command("augroup TranslateHighlight")
   api.nvim_command("autocmd!")
   api.nvim_command(
-    "autocmd BufEnter,BufRead *.jsx,*.tsx lua require('i18n-menu').highlight_translation_references()")
+    "autocmd BufEnter,BufRead *.js,*.ts,*.jsx,*.tsx lua require('i18n-menu').highlight_translation_references()")
   api.nvim_command(
     "autocmd InsertLeave *.jsx,*.tsx lua require('i18n-menu').highlight_translation_references()")
   api.nvim_command("augroup END")

--- a/lua/i18n-menu/util.lua
+++ b/lua/i18n-menu/util.lua
@@ -162,7 +162,6 @@ end
 
 function M.get_translation_key()
   local bufnr = api.nvim_get_current_buf()
-  local config = M.read_config_file()
   local cursor = api.nvim_win_get_cursor(0)
   local row, col = cursor[1] - 1, cursor[2]
 
@@ -170,20 +169,15 @@ function M.get_translation_key()
   local tree = parser:parse()[1]
   local root = tree:root()
 
-  local translation_key
-
   for _, query in ipairs(M.translation_reference_queries()) do
     for _, match in query:iter_matches(root, bufnr, row, row + 1) do
       local translation_key_node = match[#match]
-      local start_row, start_col, end_row, end_col = translation_key_node:range()
+      local start_row, start_col, _, end_col = translation_key_node:range()
       if row == start_row and col >= start_col and col <= end_col then
-        translation_key = ts.get_node_text(translation_key_node, bufnr)
-        break
+        return ts.get_node_text(translation_key_node, bufnr)
       end
     end
   end
-
-  return translation_key
 end
 
 function M.highlight_group(is_present)

--- a/lua/i18n-menu/util.lua
+++ b/lua/i18n-menu/util.lua
@@ -141,7 +141,7 @@ function M.translation_reference_queries()
   local config = M.read_config_file()
   local queries = {}
 
-  local function_name = config and config.function_name or "t"
+  local function_name = dig.dig(config, "function_name") or "t"
   table.insert(queries, ts.query.parse('javascript', string.format([[
       (call_expression
           function: (identifier) @func_name (#eq? @func_name "%s")

--- a/lua/i18n-menu/util.lua
+++ b/lua/i18n-menu/util.lua
@@ -139,10 +139,9 @@ end
 
 function M.translation_reference_queries()
   local config = M.read_config_file()
-  local queries = {}
 
-  local function_name = config and config.function_name or "t"
-  table.insert(queries, ts.query.parse('javascript', string.format([[
+  local default_function_name = config and config.function_name or "t"
+  local default_pattern = string.format([[
       (call_expression
           function: (identifier) @func_name (#eq? @func_name "%s")
           arguments: (arguments
@@ -151,7 +150,11 @@ function M.translation_reference_queries()
               )
           )
       )
-  ]], function_name)))
+  ]], default_function_name)
+
+  local queries = {}
+
+  table.insert(queries, ts.query.parse('javascript', default_pattern))
 
   for _, pattern in ipairs(config and config.function_patterns or {}) do
     table.insert(queries, ts.query.parse('javascript', pattern))

--- a/lua/i18n-menu/util.lua
+++ b/lua/i18n-menu/util.lua
@@ -137,6 +137,29 @@ function M.get_translation_files()
   return translation_files
 end
 
+function M.translation_reference_queries()
+  local config = M.read_config_file()
+  local queries = {}
+
+  local function_name = config and config.function_name or "t"
+  table.insert(queries, ts.query.parse('javascript', string.format([[
+      (call_expression
+          function: (identifier) @func_name (#eq? @func_name "%s")
+          arguments: (arguments
+              (string
+                  (string_fragment) @translation_key
+              )
+          )
+      )
+  ]], function_name)))
+
+  for _, pattern in ipairs(dig.dig(config, "function_patterns") or {}) do
+    table.insert(queries, ts.query.parse('javascript', pattern))
+  end
+
+  return queries
+end
+
 function M.get_translation_key()
   local bufnr = api.nvim_get_current_buf()
   local config = M.read_config_file()
@@ -147,27 +170,19 @@ function M.get_translation_key()
   local tree = parser:parse()[1]
   local root = tree:root()
 
-  local function_name = config and config.function_name or "t"
-  local query = ts.query.parse('javascript', string.format([[
-        (call_expression
-            function: (identifier) @func_name (#eq? @func_name "%s")
-            arguments: (arguments
-                (string
-                    (string_fragment) @translation_key
-                )
-            )
-        )
-    ]], function_name))
-
   local translation_key
-  for _, match in query:iter_matches(root, bufnr, row, row + 1) do
-    local translation_key_node = match[#match]
-    local start_row, start_col, end_row, end_col = translation_key_node:range()
-    if row == start_row and col >= start_col and col <= end_col then
-      translation_key = ts.get_node_text(translation_key_node, bufnr)
-      break
+
+  for _, query in ipairs(M.translation_reference_queries()) do
+    for _, match in query:iter_matches(root, bufnr, row, row + 1) do
+      local translation_key_node = match[#match]
+      local start_row, start_col, end_row, end_col = translation_key_node:range()
+      if row == start_row and col >= start_col and col <= end_col then
+        translation_key = ts.get_node_text(translation_key_node, bufnr)
+        break
+      end
     end
   end
+
   return translation_key
 end
 

--- a/lua/i18n-menu/util.lua
+++ b/lua/i18n-menu/util.lua
@@ -141,7 +141,7 @@ function M.translation_reference_queries()
   local config = M.read_config_file()
   local queries = {}
 
-  local function_name = dig.dig(config, "function_name") or "t"
+  local function_name = config and config.function_name or "t"
   table.insert(queries, ts.query.parse('javascript', string.format([[
       (call_expression
           function: (identifier) @func_name (#eq? @func_name "%s")
@@ -153,7 +153,7 @@ function M.translation_reference_queries()
       )
   ]], function_name)))
 
-  for _, pattern in ipairs(dig.dig(config, "function_patterns") or {}) do
+  for _, pattern in ipairs(config and config.function_patterns or {}) do
     table.insert(queries, ts.query.parse('javascript', pattern))
   end
 


### PR DESCRIPTION
## Summary

- Adds `function_patterns` config option to support custom treesitter query patterns for matching translation keys
- Extends autocmd file patterns to include `*.js` and `*.ts` files (in addition to `*.jsx` and `*.tsx`)

## Use case

The default pattern only matches simple function calls like `t("key")`. With `function_patterns`, you can match additional patterns like:

- JSX attributes: `<Trans i18nKey="key">`
- Method calls: `i18n.t("key")`

## Example configuration

```json
{
  "function_name": "translate",
  "function_patterns": [
    "(jsx_attribute (property_identifier) @prop_name (#eq? @prop_name \"i18nKey\") (string (string_fragment) @translation_key))",
    "(call_expression function: (member_expression object: (identifier) @object_name property: (property_identifier) @prop_name (#eq? @prop_name \"t\")) arguments: (arguments (string (string_fragment) @translation_key)))"
  ],
}
```

This matches:

```tsx
// Matched by function_name: "translate"
translate("otp.Confirm")

// Matched by first pattern (i18nKey JSX attribute)
<Trans t={translate} i18nKey="otp.Resend">
  Didn't get the code?
</Trans>

// Matched by second pattern (method call .t())
i18n.t("some.key")
```

🤖 Generated with https://claude.com/claude-code